### PR TITLE
Fix TypeError: save_additional_metrics() takes 5 positional arguments…

### DIFF
--- a/run.py
+++ b/run.py
@@ -181,7 +181,7 @@ def main():
 
     # Additional metrics storage based on user request
     if args.add_results:
-        save_additional_metrics(model, args, history, test_result, elapsed_training_time, train_data, current_directory, capture_weights_callback)
+        save_additional_metrics(model, args, train_data, current_directory, capture_weights_callback)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
… but 8 were given

While running training, using:
`sh run_script.sh -m transformer -d ETTh1 -u -a` 

When the code hits the `early stopping` point, I ran into the error:

```
Traceback (most recent call last):
  File "/samformer/run.py", line 187, in <module>
    main()
  File "/samformer/run.py", line 184, in main
    save_additional_metrics(model, args, history, test_result, elapsed_training_time, train_data, current_directory, capture_weights_callback)
TypeError: save_additional_metrics() takes 5 positional arguments but 8 were given
```

Saw the function definition and looked like a quick fix, so went ahead and updated the function call.  Tested running training and all worked without any errors. 